### PR TITLE
Use inhibit-read-only instead of buffer-read-only

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -132,7 +132,7 @@ untouched."
   (declare (indent 0))
   `(save-excursion
      (let ((buffer-undo-list t)
-           (buffer-read-only nil)
+           (inhibit-read-only t)
            (modified (buffer-modified-p)))
        (unwind-protect
            (progn ,@body)


### PR DESCRIPTION
This will fix the problem with EIN: tkf/emacs-ipython-notebook#42
See also the discussions in m2ym/auto-complete#115
