### PR TITLE
Summary overflow

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -412,7 +412,8 @@ usual."
                               0))))
          (string (car (popup-substring-by-width string content-width)))
          (string-width (string-width string))
-         (spacing (max (- popup-width string-width summary-width) 0)))
+         (spacing (max (- popup-width string-width summary-width)
+                       (if (> popup-width string-width) 1 0))))
     (concat margin-left
             string
             (make-string spacing ? )


### PR DESCRIPTION
Popup menu is cluttered when
1. cursor is close to the right edge of window and
2. summary is long (e.g., longer than `current column - window width`).

This PR fixes this problem.
