### PR TITLE
Generic filtering callback support for popup-isearch w/example filter by docstring

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -603,9 +603,11 @@ KEYMAP is a keymap that will be put on the popup contents."
           (when (< current-column column)
             ;; Extend short buffer lines by popup prefix (line of spaces)
             (setq prefix (make-string
-                          (+ (if (= current-column 0)
-                                 (- window-hscroll (current-column))
-                               0)
+                          (+ 
+			   (if (= current-column 0)
+			       0
+			       ;(- window-hscroll (current-column))
+			     0)
                              (- column current-column))
                           ? )))
 


### PR DESCRIPTION
I've found the docstring search case useful for searching for function argument types, keywords like deprecated, async, callback, and even elisp defun keywords like &rest and &key.

I thought that rather than just add docstring, generic filtering functionality should be exposed.

I've submitted this pull request as a potential fix for issue #39

Example use of this patch w/auto-complete:

```
(defun ac-isearch-doc ()
  (interactive)
  (when (ac-menu-live-p)
    (ac-cancel-show-menu-timer)
    (ac-show-menu)
    (if ac-use-quick-help
        (let ((popup-menu-show-quick-help-function
               (if (ac-quick-help-use-pos-tip-p)
                   'ac-pos-tip-show-quick-help
                 'popup-menu-show-quick-help)))
          (popup-isearch ac-menu
                         :callback 'ac-isearch-callback
                         :help-delay ac-quick-help-delay
             :filter 'popup-isearch-filter-list-by-doc))
      (popup-isearch ac-menu 
             :callback 'ac-isearch-callback
             :filter 'popup-isearch-filter-list-by-doc))))
```
