### PR TITLE
Allow propertized text in tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ Here is an example:
     (popup-tip "Hello, World!")
     ;; reach here after the tooltip disappeared
 
+### Function: `popup-tip-propertized`
+
+A version of `popup-tip` that doesn't strip text properties (faces)
+from the string. Can be used to customize tooltip appearance beyond
+a single `popup-tip-face`. Takes the same arguments as `popup-tip`.
+
 Popup Menus
 -----------
 

--- a/popup.el
+++ b/popup.el
@@ -975,7 +975,7 @@ HELP-DELAY is a delay of displaying helps."
 
 (defvar popup-tip-max-width 80)
 
-(defun* popup-tip (string
+(defun* popup-tip-propertized (string
                    &key
                    point
                    (around t)
@@ -992,7 +992,7 @@ HELP-DELAY is a delay of displaying helps."
                    nowait
                    prompt
                    &aux tip lines)
-  "Show a tooltip of STRING at POINT. This function is
+  "Show a tooltip of STRING with properties at POINT. This function is
 synchronized unless NOWAIT specified. Almost arguments are same
 as `popup-create' except for TRUNCATE, NOWAIT, and PROMPT.
 
@@ -1004,8 +1004,6 @@ tooltip instance without entering event loop.
 PROMPT is a prompt string when reading events during event loop."
   (if (bufferp string)
       (setq string (with-current-buffer string (buffer-string))))
-  ;; TODO strip text (mainly face) properties
-  (setq string (substring-no-properties string))
 
   (and (eq margin t) (setq margin 1))
   (or margin-left (setq margin-left margin))
@@ -1042,6 +1040,13 @@ PROMPT is a prompt string when reading events during event loop."
           t))
     (unless nowait
       (popup-delete tip))))
+
+(defun popup-tip (string &rest args)
+  "Show a tooltip of STRING without properties at POINT. This function
+is the same as `popup-tip-propertized' except that it strips text
+properties."
+  ;; strip text (mainly face) properties
+  (apply 'popup-tip-propertized (substring-no-properties string) args))
 
 
 


### PR DESCRIPTION
こんにちは、松山さん！Please consider adding a variant of `popup-tip` that doesn't strip text properties. I need it to display function signature hints from [Tern](https://github.com/marijnh/tern) that uses the `highlight` face to mark the argument under the cursor. Thanks!
