### PR TITLE
Fix travis configuration file for using cl-lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: emacs-lisp
 before_install:
   - git submodule update --init
+  - make tests/cl-lib.el
   - if [ "$EMACS" = 'emacs-snapshot' ]; then
       sudo add-apt-repository -y ppa:cassou/emacs &&
       sudo apt-get update -qq &&

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ travis-ci:
 
 tests/ert.el:
 	wget "http://git.savannah.gnu.org/cgit/emacs.git/plain/lisp/emacs-lisp/ert.el" -O $@
+
+tests/cl-lib.el:
+	wget "http://elpa.gnu.org/packages/cl-lib-0.3.el" -O $@


### PR DESCRIPTION
cl-lib is not default package before Emacs 24.3. So it should be
installed before tests.
