### PR TITLE
fixed deficient help-delay

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -1192,7 +1192,7 @@ PROMPT is a prompt string when reading events during event loop."
                           :help-delay help-delay)
            (keyboard-quit))
       (setq key (popup-menu-read-key-sequence keymap prompt help-delay))
-      (setq binding (ignore-errors (lookup-key keymap key)))
+      (setq binding (and key (lookup-key keymap key)))
       (cond
        ((or (null key) (zerop (length key)))
         (unless (funcall popup-menu-show-quick-help-function menu nil :prompt prompt)


### PR DESCRIPTION
When I did eval of the following code, the error was shown, which is `(wrong-type-argument arrayp nil)`.

``` lisp
(popup-cascade-menu '(Foo (Bar Baz) (Hoge Fuga))
                    :help-delay 1.5)
```

The cause is `lookup-key` that is called with nil by the timeout of `popup-menu-read-key-sequence`.

In addition, the menu item help was not shown because the help-delay slot is deficient when do `popup-cascade-menu` to the sublist of the menu.

Best regards.
