### PR TITLE
activate isearch in cascade menu

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -887,6 +887,8 @@ Pages up through POPUP."
   (let ((map (make-sparse-keymap)))
     ;(define-key map "\r"        'popup-isearch-done)
     (define-key map "\C-g"      'popup-isearch-cancel)
+    (define-key map "\C-b"      'popup-isearch-close)
+    (define-key map [left]      'popup-isearch-close)
     (define-key map "\C-h"      'popup-isearch-delete)
     (define-key map (kbd "DEL") 'popup-isearch-delete)
     map))
@@ -980,6 +982,11 @@ HELP-DELAY is a delay of displaying helps."
                ((eq binding 'popup-isearch-cancel)
                 (popup-isearch-update popup "" callback)
                 (cl-return t))
+               ((eq binding 'popup-isearch-close)
+                (popup-isearch-update popup "" callback)
+                (setq unread-command-events
+                      (append (listify-key-sequence key) unread-command-events))
+                (cl-return nil))
                ((eq binding 'popup-isearch-delete)
                 (if (> (length pattern) 0)
                     (setq pattern (substring pattern 0 (1- (length pattern))))))
@@ -1219,7 +1226,11 @@ PROMPT is a prompt string when reading events during event loop."
                                                :scroll-bar (popup-scroll-bar menu)
                                                :parent menu
                                                :parent-offset index
-                                               :help-delay help-delay))
+                                               :help-delay help-delay
+                                               :isearch isearch
+                                               :isearch-cursor-color isearch-cursor-color
+                                               :isearch-keymap isearch-keymap
+                                               :isearch-callback isearch-callback))
                   (and it (cl-return it)))
             (if (eq binding 'popup-select)
                 (cl-return (popup-item-value-or-self item))))))


### PR DESCRIPTION
At present, isearch is not active automatically in the child menu even if do `popup-cascade-menu :isearch t`.
Because, the isearch condition is not passed on to `popup-cascade-menu`, which is called by `popup-select`/`popup-open` in `popup-menu-event-loop`.
But, I think it's not a natural behavior.

In addition, the parent menu is not focused by `popup-close` in the child menu.
So, I added the case of pushing the key that is equal to `popup-close` in `popup-isearch`.

Best regards.
