### PR TITLE
avoid freeze from big cascade menu

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -1379,10 +1379,9 @@ If the popup menu format is not cascade, This value is no need."
   (unwind-protect
       (progn
         (popup-set-list menu
-                        (cl-loop with idx = 0
-                                 for e in list
-                                 collect (popup-make-item e :rawindex idx)
-                                 do (incf idx)))
+                        (cl-loop for e in list
+                                 for idx = 0 then (1+ idx)
+                                 collect (popup-make-item e :rawindex idx)))
         (if cursor
             (popup-jump menu cursor)
           (popup-draw menu))


### PR DESCRIPTION
When do `popup-cascade-menu` using big list, 
I encountered the freeze and memory consumption increase of Emacs.
And the following message was shown.

```
Emergency (alloc): Warning: past 85% of memory limit
```

Then, I've been able to avoid it by the following change.
- The sublist, which is the child list of current menu item, is not stored into text-property.
- The original index of the menu item is stored into text-property for finding the cascade index of current menu.

In addition, I think the sublist slot of `popup-menu*` should be deprecated.
So, I've appended the comment about it.

Best regards.

---

英語が不得手なので、日本語で一応補足します。

`popup-cascade-menu`を使わせて頂いているのですが、巨大なカスケードメニューを作ってみた所、
子メニューを辿ったり、スクロールしたり、C-gで終了しようとした時に、Emacsがフリーズし、使用メモリ量が急上昇します。

現在は、カスケードされる子メニューのリストを親メニュー要素のテキストプロパティで保持していますが、
それを`popup-menu-event-loop`に引数で渡すようにすることで解決できました。
ただ、isearchで絞り込んだ場合、親メニュー要素の本来の順番が不明になり、
対応する子メニューが判別できなくなってしまうため、各メニュー要素に本来の順番をテキストプロパティで保持するようにしました。

あと、sublistスロットは今後使うべきでないと思うので、その旨のコメントを加えました。

現在、popup.elを使った拡張を作っているのですが、フリーズしてしまうのは何とかして避けたいです。
どうぞ宜しくお願い致します。
