### PR TITLE
fix error on popup-delete when char-before return nil

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -674,7 +674,8 @@ KEYMAP is a keymap that will be put on the popup contents."
         (popup-save-buffer-state
           (goto-char (point-max))
           (dotimes (i newlines)
-            (if (= (char-before) ?\n)
+            (if (and (char-before)
+                     (= (char-before) ?\n))
                 (delete-char -1)))))))
   nil)
 


### PR DESCRIPTION
When make popup on empty buffer, `popup-delete` errors.
The reason is `char-before` returns `nil`.
