### PR TITLE
:initial-index respects real popup height(beyond first popup page)

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -1384,8 +1384,8 @@ If `INITIAL-INDEX' is non-nil, this is an initial index value for
             (popup-jump menu cursor)
           (popup-draw menu))
         (when initial-index
-          (popup-select menu
-                        (min (- (length list) 1) initial-index)))
+          (dotimes (counter (min (- (length list) 1) initial-index))
+              (popup-next menu)))
         (if nowait
             menu
           (popup-menu-event-loop menu keymap fallback

--- a/tests/popup-test.el
+++ b/tests/popup-test.el
@@ -628,6 +628,10 @@ Qux" :nowait t)
     (should (popup-test-helper-popup-selected-item "Baz")))
 
   (popup-test-with-common-setup
+    (setq popup (popup-menu* '("Foo" "Bar" "Baz") :initial-index 2 :height 1 :scroll-bar t :nowait t))
+    (should (popup-test-helper-popup-selected-item "Baz")))
+
+  (popup-test-with-common-setup
     (setq popup (popup-menu* '("Foo" "Bar" "Baz") :initial-index -1 :nowait t))
     (should (popup-test-helper-popup-selected-item "Foo")))
 


### PR DESCRIPTION
Hi. I hit the problem with `:initial-index` only selecting items at the first page on the popup.
Should be working fine now. 

`cask exec emacs -batch -Q -l tests/run-test.el` gives `Ran 33 tests, 33 results as expecte`.

Thank you. Hope this is helpfull.
