### PR TITLE
Pass filtering function as an argument to popup-menu*

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,13 +273,14 @@ select an item of a list.
 
     popup-menu* list &key point around width height margin margin-left
     margin-right scroll-bar symbol parent parent-offset keymap
-    fallback help-delay nowait prompt isearch isearch-cursor-color
+    fallback help-delay nowait prompt isearch isearch-filter isearch-cursor-color
     isearch-keymap isearch-callback initial-index => selected-value
 
 Show a popup menu of `LIST` at `POINT`. This function returns the value
 of the selected item. Almost all arguments are same as `popup-create`
 except for `KEYMAP`, `FALLBACK`, `HELP-DELAY`, `PROMPT`, `ISEARCH`,
-`ISEARCH-CURSOR-COLOR`, `ISEARCH-KEYMAP`, and `ISEARCH-CALLBACK`.
+`ISEARCH-FILTER`, `ISEARCH-CURSOR-COLOR`, `ISEARCH-KEYMAP`
+and `ISEARCH-CALLBACK`.
 
 If `KEYMAP` is provided, it is a keymap which is used when processing
 events during event loop.
@@ -298,6 +299,9 @@ instance without entering event loop.
 
 If `ISEARCH` is non-nil, do isearch as soon as displaying the popup
 menu.
+
+`ISEARCH-FILTER` is a filtering function taking two arguments:
+search pattern and list of items. Returns a list of matching items.
 
 `ISEARCH-CURSOR-COLOR` is a cursor color during isearch. The default
 value is `popup-isearch-cursor-color'.

--- a/tests/popup-test.el
+++ b/tests/popup-test.el
@@ -656,7 +656,7 @@ Qux" :nowait t)
 foo
 bar
 baz")
-    (popup-isearch-update popup "a")
+    (popup-isearch-update popup 'popup-isearch-filter-list "a")
     (should (popup-test-helper-rectangle-match "\
 bar
 baz"))


### PR DESCRIPTION
Hi. I was trying to use fuzzy matching inside a popup menu and only way I could do it was defadvice'ing `popup-isearch-filter-list` function. Instead I lifter it to parameters of `popup-menu*` so that I could use it with custom filtering function. Please, let me know if there is another way or, please, consider this PR. Thank yon in advance.