### PR TITLE
Fix for Emacs 24.5 issue

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -378,16 +378,15 @@ usual."
       (put-text-property start (length content) 'face face content))
     (when mouse-face
       (put-text-property 0 (length content) 'mouse-face mouse-face content))
-    (unless (overlay-get overlay 'dangle)
-      (overlay-put overlay 'display (concat prefix (substring content 0 1)))
-      (setq prefix nil
-            content (concat (substring content 1))))
-    (overlay-put overlay
-                 'after-string
-                 (concat prefix
-                         content
-                         scroll-bar-char
-                         postfix))))
+    (let ((prop (if (overlay-get overlay 'dangle)
+                    'after-string
+                  'display)))
+      (overlay-put overlay
+                   prop
+                   (concat prefix
+                           content
+                           scroll-bar-char
+                           postfix)))))
 
 (cl-defun popup-create-line-string (popup
                                     string


### PR DESCRIPTION
On Emacs 24.5 or higher, string in 'after-string' of overlay which sets 'display'
property at same time does not display in some cases.

(However I don't understand well this issue.)


#### Original code

![before](https://cloud.githubusercontent.com/assets/554281/8376866/c0e3d064-1c46-11e5-93ec-0c3001f850fe.png)

In this case, 3rd line in quick help tooltip, string of `'display` property is ` '` and string of `'after-string` is `byte-run.el' .`. Emacs displays only `'display' property.

#### Apply this patch

![after](https://cloud.githubusercontent.com/assets/554281/8376869/c89842b8-1c46-11e5-92eb-f6cad9806cf7.png)

I confirmed this patch works on Emacs 24.4 or lower.