### PR TITLE
Allow the user to specify a custom function to build the regexp in isearch

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -887,13 +887,18 @@ Pages up through POPUP."
 (defvar popup-menu-show-quick-help-function 'popup-menu-show-quick-help
   "Function used for showing quick help by `popup-menu*'.")
 
+(defcustom popup-isearch-regexp-builder-function 'regexp-quote
+  "Function used to construct a regexp from a pattern. You may for instance
+  provide a function that replaces spaces by '.+' if you like helm or ivy style
+  of completion.")
+
 (defsubst popup-isearch-char-p (char)
   (and (integerp char)
        (<= 32 char)
        (<= char 126)))
 
 (defun popup-isearch-filter-list (pattern list)
-  (cl-loop with regexp = (regexp-quote pattern)
+  (cl-loop with regexp = (funcall popup-isearch-regexp-builder-function pattern)
            for item in list
            do
            (unless (stringp item)


### PR DESCRIPTION
If the user likes to use helm or ivy style of matching candidates,
they can provide their own regexp builer.

For instance, in case you like to 'foo bar' to match 'foo.+bar',
you can provide a function that replaces spaces by '.+'.

For instance, I set popup-isearch-regexp-builder-function to ivy--regex-plus. (see https://github.com/abo-abo/swiper/blob/master/ivy.el#L1418)