### PR TITLE
extend overriding of background face for isearch, selection

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -868,7 +868,7 @@ Pages up through POPUP."
 ;;; Popup Incremental Search
 
 (defface popup-isearch-match
-  '((t (:background "sky blue")))
+  '((t (:inherit default :background "sky blue")))
   "Popup isearch match face."
   :group 'popup)
 
@@ -1100,7 +1100,7 @@ PROMPT is a prompt string when reading events during event loop."
   :group 'popup)
 
 (defface popup-menu-selection-face
-  '((t (:background "steelblue" :foreground "white")))
+  '((t (:inherit default :background "steelblue" :foreground "white")))
   "Face for popup menu selection."
   :group 'popup)
 


### PR DESCRIPTION
This extends the fix for issue 105 (inhering popup face from default in order to avoid background text properties from bleeding through to popup) to also handle other popup-faces that were problematic:

 - the foreground selection face
 - isearch results
