### PR TITLE
Count only visible lines for popup direction

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -436,7 +436,7 @@ usual."
   "Return a proper direction when displaying a popup on this
 window. HEIGHT is the a height of the popup, and ROW is a line
 number at the point."
-  (let* ((remaining-rows (- (max 1 (- (window-height)
+  (let* ((remaining-rows (- (max 1 (- (window-text-height)
                                       (if mode-line-format 1 0)
                                       (if header-line-format 1 0)))
                             (count-lines (window-start) (point))))


### PR DESCRIPTION
This prevents the popup from displaying past the end of a window in GUI Emacs.