### PR TITLE
fixes left margin alignment on emacs-26 and master

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -150,6 +150,8 @@ untouched."
 
 (defun popup-vertical-motion (column direction)
   "A portable version of `vertical-motion'."
+  (if (functionp 'line-number-display-width)
+      (setq column (- column (line-number-display-width 'columns))))
   (if (>= emacs-major-version 23)
       (vertical-motion (cons column direction))
     (vertical-motion direction)


### PR DESCRIPTION
the alignment of the left margin in the candidate list is broken on emacs-26
and master due to a chanage in `vertical-motion'. see
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=31966 for more information.

This patch checks for the presence of `line-number-display-width', and use it
to subtract the number of columns used to display line numbers.