### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -42,7 +42,7 @@
 ;;; Utilities
 
 (defun popup-calculate-max-width (max-width)
-  "Determines whether the width with MAX-WIDTH desired is character or window \
+  "Determines whether the width with MAX-WIDTH desired is character or window
 proportion based, And return the result."
   (cl-typecase max-width
     (integer max-width)


### PR DESCRIPTION
```
 ■  Warning (comp): popup.el:46:2: Warning: docstring wider than 80 characters
```

To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.