### PR TITLE
Make popup-replace-displayable much faster

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -244,15 +244,15 @@ ITEM is not string."
 
 Optional argument REP is the replacement string of
 non-displayable character."
-  (unless rep (setq rep ""))
-  (let ((result ""))
+  (let ((rep (or rep ""))
+        (results (list)))
     (dolist (string (split-string str ""))
       (let* ((char (string-to-char string))
              (string (if (char-displayable-p char)
                          string
                        rep)))
-        (setq result (concat result string))))
-    result))
+        (push string results)))
+    (string-join (reverse results))))
 
 (cl-defun popup-make-item (name
                            &key


### PR DESCRIPTION
One of my users reported a performance bug, which I tracked down to `popup-replace-displayable` (https://github.com/gcv/julia-snail/issues/110).

Calling `popup-replace-displayable` takes ~3 seconds on a string of about 8000 characters on my system, and becomes much slower on larger inputs.

The attached PR eliminates the large number of string concatenations and significantly improves the function's performance.