### PR TITLE
perf(popup.el): enable lexical binding

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -1,4 +1,4 @@
-;;; popup.el --- Visual Popup User Interface
+;;; popup.el --- Visual Popup User Interface  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2009-2015  Tomohiro Matsuyama
 ;; Copyright (c) 2020-2023 Jen-Chieh Shen


### PR DESCRIPTION
Upon inspecting the code, I do not see anything can present a problem with enabling lexical-binding. One day Emacs will enable lexical binding by default so it's better merge this earlier to reduce the risk of a mass config breakage event.

This is a re-opening of #139, which I accidentally clobbered.