### PR TITLE
do NOT hide tab bar of tab-bar-mode when popup-menu* executeing.

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -1195,6 +1195,7 @@ If FACE is non-nil, it will be used instead of face `popup-tip-face'."
                                  temp-global-map old-global-map)
       (define-key temp-global-map [menu-bar] (lookup-key old-global-map [menu-bar]))
       (define-key temp-global-map [tool-bar] (lookup-key old-global-map [tool-bar]))
+      (define-key temp-global-map [tab-bar] (lookup-key old-global-map [tab-bar]))
       (set-keymap-parent overriding-terminal-local-map keymap)
       (if (current-local-map)
           (define-key overriding-terminal-local-map [menu-bar]


### PR DESCRIPTION
Reproduce:

```
(tab-bar-mode t) ;; -> show tab-bar
(require 'popup)
(popup-menu* '(a b)) ;; → hide tab-bar
```

Cause:

1. popup-menu-read-key-sequence replaces current global-map to temp-global-map temporarily.
2. temp-global-map do not have tab-bar's map.
3. so, tab-bar disappears when popup-menu* executes.

Fix:

add tab-bar's map to temp-global-map same as menu-bar and tool-bar.

Environment;

Emacs 29.3
Debian GNU/Linux sid (6.7.12-amd64)

![popup-el-and-tab-bar](https://github.com/auto-complete/popup-el/assets/297344/eba0f365-2a82-4a00-b9aa-4ae1b1ddc0cf)